### PR TITLE
Fix Storage Worker exception

### DIFF
--- a/lib/crawly/requests_storage/requests_storage.ex
+++ b/lib/crawly/requests_storage/requests_storage.ex
@@ -160,7 +160,7 @@ defmodule Crawly.RequestsStorage do
           {{:ok, pid}, new_state}
 
         _ ->
-          {{:error, :already_started}, state.workers}
+          {{:error, :already_started}, state}
       end
 
     {:reply, msg, new_state}

--- a/test/engine_test.exs
+++ b/test/engine_test.exs
@@ -14,6 +14,11 @@ defmodule EngineTest do
     end)
   end
 
+  test "starting a running spider returns an error" do
+    Crawly.Engine.start_spider(TestSpider)
+    assert {:error, :spider_already_started} Crawly.Engine.start_spider(TestSpider) 
+  end
+
   test "list_known_spiders/0 lists all spiders and their current status in the engine" do
     Crawly.Engine.refresh_spider_list()
     spiders = Crawly.Engine.list_known_spiders()

--- a/test/request_storage_test.exs
+++ b/test/request_storage_test.exs
@@ -23,6 +23,19 @@ defmodule RequestStorageTest do
     {:ok, %{crawler: :test_spider}}
   end
 
+  test "Starting a worker twice doesn't break", context do
+    Crawly.RequestsStorage.start_worker(:test_spider, "crawl_id")
+
+    request = %Crawly.Request{
+      url: "http://example.com",
+      headers: [],
+      options: []
+    }
+
+    assert :ok = Crawly.RequestsStorage.store(context.crawler, request)
+    assert %Crawly.Request{} = Crawly.RequestsStorage.pop(context.crawler)
+  end
+
   test "Request storage can store requests", context do
     request = %Crawly.Request{
       url: "http://example.com",


### PR DESCRIPTION
Starting the same worker twice in a row was corrupting the `Crawly.RequestsStorage` GenServer state. 