### PR TITLE
Make WriteToFile pipeline more robust

### DIFF
--- a/lib/crawly/pipelines/write_to_file.ex
+++ b/lib/crawly/pipelines/write_to_file.ex
@@ -107,7 +107,7 @@ defmodule Crawly.Pipelines.WriteToFile do
              item: any()
   defp write(io, item) do
     try do
-      IO.write(io, item)
+      IO.write(io, inspect(item))
       IO.write(io, "\n")
     catch
       error, reason ->


### PR DESCRIPTION
Currently the pipeline will try to write given items to file but if the items do not implement String.Chars it will crash. By using Kernel.inspect any term can be saved without having to explicitly implement the protocol.

This was discovered in an example where the pipeline tried to write Crawly.Request structs but failed due to the struct not implementing String.Chars.