### PR TITLE
Changed the config use Mix.Config to import Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :crawly,
   manager_operations_timeout: 500,


### PR DESCRIPTION
I just changed the 
use Mix.Config to import Config
as stated by the compiler warnings.
Tests are passing.