### PR TITLE
Fixes weird GenServer bug

### DIFF
--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -38,7 +38,7 @@ defmodule Crawly.Worker do
     # Get a request from requests storage.
     new_backoff =
       case Crawly.RequestsStorage.pop(spider_name) do
-        nil ->
+        n when n in [nil, :ok] ->
           # Slow down a bit when there are no new URLs
           backoff * 2
 


### PR DESCRIPTION
As pointed out in this issue
https://github.com/elixir-crawly/crawly/issues/224, `GenServer.call(__MODULE__, {:pop, Elixir.Homebase})`, which is invoked from the worker.ex
[here](https://github.com/elixir-crawly/crawly/blob/13fe05b400db46716729bd15e4ef1b67d12db5ee/lib/crawly/worker.ex#L40), returns the value `:ok`, shortly after starting the spider. With this change, the worker treats the returned `:ok` value similar to a returned `nil`, and waits for a request to be available.