### PR TITLE
Introduce SameDomainFilter

### DIFF
--- a/documentation/basic_concepts.md
+++ b/documentation/basic_concepts.md
@@ -44,7 +44,7 @@ compatibility is kept with a help of macro which always generates `init/1`.
 `init(options)` same as `init/0` but also takes options (which can be passed from the engine during
 the spider start).
 
-`base_url()` - defines a base_url of the given Spider. This function is used in order to filter out all requests which are going outside of the crawled website.
+`base_url()` - defines a base_url of the given Spider. This function is used by the DomainFilter in order to filter out all requests which are going outside of the crawled website.
 
 `parse_item(response)` - a function which defines how a given response is translated into the `Crawly.ParsedItem` structure. On the high level this function defines the extraction rules for both Items and Requests.
 
@@ -118,12 +118,13 @@ Note that all request configuration options for `HTTPoison`, such as proxy, ssl,
 
 Built-in middlewares:
 
-1. `Crawly.Middlewares.DomainFilter` - this middleware will disable scheduling for all requests leading outside of the crawled site.
-2. `Crawly.Middlewares.RobotsTxt` - this middleware ensures that Crawly respects the robots.txt defined by the target website.
-3. `Crawly.Middlewares.UniqueRequest` - this middleware ensures that crawly will not schedule the same URL(request) multiple times.
-4. `Crawly.Middlewares.UserAgent` - this middleware is used to set a User Agent HTTP header. Allows to rotate UserAgents, if the last one is defined as a list.
-5. `Crawly.Middlewares.RequestOptions` - allows to set additional request options, for example timeout, of proxy string (at this moment the options should match options of the individual fetcher (e.g. HTTPoison))
-6. `Crawly.Middlewares.AutoCookiesManager` - allows to turn on the automatic cookies management. Useful for cases when you need to login or enter form data used by a website.
+1. `Crawly.Middlewares.DomainFilter` - this middleware will disable scheduling for all requests leading outside of the crawled site, based on base_url.
+2. `Crawly.Middlewares.SameDomainFilter` - this middleware filters by domain as well but does not require base_url to be set, instead the start_url is considered.
+3. `Crawly.Middlewares.RobotsTxt` - this middleware ensures that Crawly respects the robots.txt defined by the target website.
+4. `Crawly.Middlewares.UniqueRequest` - this middleware ensures that crawly will not schedule the same URL(request) multiple times.
+5. `Crawly.Middlewares.UserAgent` - this middleware is used to set a User Agent HTTP header. Allows to rotate UserAgents, if the last one is defined as a list.
+6. `Crawly.Middlewares.RequestOptions` - allows to set additional request options, for example timeout, of proxy string (at this moment the options should match options of the individual fetcher (e.g. HTTPoison))
+7. `Crawly.Middlewares.AutoCookiesManager` - allows to turn on the automatic cookies management. Useful for cases when you need to login or enter form data used by a website.
    Example:
    ```elixir
     {Crawly.Middlewares.RequestOptions, [timeout: 30_000, recv_timeout: 15000]},

--- a/examples/quickstart/config/config.exs
+++ b/examples/quickstart/config/config.exs
@@ -7,7 +7,7 @@ config :crawly,
   closespider_itemcount: 100,
 
   middlewares: [
-    Crawly.Middlewares.DomainFilter,
+    Crawly.Middlewares.SameDomainFilter,
     Crawly.Middlewares.UniqueRequest,
     {Crawly.Middlewares.UserAgent, user_agents: ["Crawly Bot"]}
   ],

--- a/examples/quickstart/lib/quickstart/books_spider.ex
+++ b/examples/quickstart/lib/quickstart/books_spider.ex
@@ -2,12 +2,12 @@ defmodule BooksToScrape do
   use Crawly.Spider
 
   @impl Crawly.Spider
-  def base_url(), do: "https://books.toscrape.com/"
-
-  @impl Crawly.Spider
   def init() do
     [start_urls: ["https://books.toscrape.com/"]]
   end
+
+  @impl Crawly.Spider
+  def base_url(), do: ""
 
   @impl Crawly.Spider
   def parse_item(response) do

--- a/lib/crawly/middlewares/same_domain_filter.ex
+++ b/lib/crawly/middlewares/same_domain_filter.ex
@@ -1,0 +1,44 @@
+defmodule Crawly.Middlewares.SameDomainFilter do
+  @moduledoc """
+  Filters out requests which are going outside of the crawled domain.
+
+  The domain that is used to compare against the request url is obtained from
+  the previous response, so it ends up being the spider's start_url. Spider's
+  base_url is not evaluated.
+
+  Does not accept any options. Tuple-based configuration optionswill be ignored.
+
+  ### Example Declaration
+  ```
+  middlewares: [
+    Crawly.Middlewares.SameDomainFilter
+  ]
+  ```
+  """
+
+  @behaviour Crawly.Pipeline
+  require Logger
+
+  def run(request, state, _opts \\ []) do
+    base_url = get_in(request, [Access.key(:prev_response), Access.key(:request_url)])
+
+    case base_url do
+      nil ->
+        # no previous request, so we assume it's the first one and let it pass
+        {request, state}
+
+      _ ->
+        base_host = URI.parse(base_url).host
+        request_host = URI.parse(request.url).host
+
+        case request_host != nil and base_host == request_host do
+          false ->
+            Logger.debug("Dropping request: #{inspect(request.url)} (domain filter)")
+            {false, state}
+
+          true ->
+            {request, state}
+        end
+    end
+  end
+end

--- a/test/middlewares/same_domain_filter_test.exs
+++ b/test/middlewares/same_domain_filter_test.exs
@@ -1,0 +1,81 @@
+defmodule Middlewares.SameDomainFilterTest do
+  use ExUnit.Case, async: false
+
+  @base_url "https://www.erlang-solutions.com"
+
+  setup do
+    :meck.new(:test_spider, [:non_strict])
+
+    on_exit(fn ->
+      :meck.unload()
+    end)
+  end
+
+  test "Initial request always passes" do
+    middlewares = [Crawly.Middlewares.SameDomainFilter]
+
+    req = %Crawly.Request{
+      url: @base_url,
+      prev_response: nil
+    }
+
+    state = %{spider_name: :test_spider, crawl_id: "id"}
+
+    {maybe_request, _state} = Crawly.Utils.pipe(middlewares, req, state)
+    assert %Crawly.Request{} = maybe_request
+  end
+
+  test "Filters out requests that do not contain a spider's start_url" do
+    middlewares = [Crawly.Middlewares.SameDomainFilter]
+
+    req = %Crawly.Request{
+      url: "https://www.some_url.com",
+      prev_response: %HTTPoison.Response{request_url: @base_url}
+    }
+
+    state = %{spider_name: :test_spider, crawl_id: "id"}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+
+  test "Does not filter out requests with correct urls" do
+    middlewares = [Crawly.Middlewares.SameDomainFilter]
+
+    req = %Crawly.Request{
+      url: "https://www.erlang-solutions.com/blog/web-scraping-with-elixir.html",
+      prev_response: %HTTPoison.Response{request_url: @base_url}
+    }
+
+    state = %{spider_name: :test_spider, crawl_id: "id"}
+
+    {maybe_request, _state} = Crawly.Utils.pipe(middlewares, req, state)
+    assert %Crawly.Request{} = maybe_request
+  end
+
+  test "Filters out 'share' urls" do
+    middlewares = [Crawly.Middlewares.SameDomainFilter]
+
+    req = %Crawly.Request{
+      url:
+        "https://twitter.com?share=https://www.erlang-solutions.com/blog/web-scraping-with-elixir.html",
+      prev_response: %HTTPoison.Response{request_url: @base_url}
+    }
+
+    state = %{spider_name: :test_spider, crawl_id: "id"}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+
+  test "Non absolute url should not crash the middleware" do
+    middlewares = [Crawly.Middlewares.SameDomainFilter]
+
+    req = %Crawly.Request{
+      url: "/blog",
+      prev_response: %HTTPoison.Response{request_url: @base_url}
+    }
+
+    state = %{spider_name: :test_spider, crawl_id: "id"}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+end


### PR DESCRIPTION
My application requires only one or two different Spiders but these are run over many different domains (passed as option to start_spider). So setting the base_url turned out to be difficult and I came up with this solution.

Thoughts?