### PR TITLE
Improve UniqueRequest

### DIFF
--- a/documentation/basic_concepts.md
+++ b/documentation/basic_concepts.md
@@ -121,7 +121,7 @@ Built-in middlewares:
 1. `Crawly.Middlewares.DomainFilter` - this middleware will disable scheduling for all requests leading outside of the crawled site, based on base_url.
 2. `Crawly.Middlewares.SameDomainFilter` - this middleware filters by domain as well but does not require base_url to be set, instead the start_url is considered.
 3. `Crawly.Middlewares.RobotsTxt` - this middleware ensures that Crawly respects the robots.txt defined by the target website.
-4. `Crawly.Middlewares.UniqueRequest` - this middleware ensures that crawly will not schedule the same URL(request) multiple times.
+4. `Crawly.Middlewares.UniqueRequest` - this middleware ensures that crawly will not schedule the same URL (request) multiple times. Optionally supports hashing to reduce the memory footprint.
 5. `Crawly.Middlewares.UserAgent` - this middleware is used to set a User Agent HTTP header. Allows to rotate UserAgents, if the last one is defined as a list.
 6. `Crawly.Middlewares.RequestOptions` - allows to set additional request options, for example timeout, of proxy string (at this moment the options should match options of the individual fetcher (e.g. HTTPoison))
 7. `Crawly.Middlewares.AutoCookiesManager` - allows to turn on the automatic cookies management. Useful for cases when you need to login or enter form data used by a website.

--- a/lib/crawly/middlewares/unique_request.ex
+++ b/lib/crawly/middlewares/unique_request.ex
@@ -1,17 +1,47 @@
 defmodule Crawly.Middlewares.UniqueRequest do
   @moduledoc """
-  Avoid scheduling requests for the same pages.
+  Avoid scheduling multiple requests for the same page. Allow to set a hashing
+  algorithm via options to reduce the memory footprint. Be aware of reduced collision
+  resistance, depending on the chosen algorithm.
+
+  ### Example Declarations
+  ```
+  middlewares: [
+    Crawly.Middlewares.UniqueRequest
+  ]
+  ```
+
+  ```
+  middlewares: [
+    {Crawly.Middlewares.UniqueRequest, hash: :sha}
+  ]
+  ```
+
+  See the [Erlang documentation for crypto](https://www.erlang.org/doc/man/crypto.html#type-sha1)
+  for available algorithms.
   """
   require Logger
 
-  def run(request, state) do
+  def run(request, state, opts \\ []) do
     unique_request_seen_requests =
       Map.get(state, :unique_request_seen_requests, %{})
 
-    case Map.get(unique_request_seen_requests, request.url) do
+    # we assume that https://example/foo and https://example/foo/ refer to the same content,
+    # in case they are both accessible
+    normalised_url = request.url |> String.replace_suffix("/", "")
+
+    # optionally hash the URL
+    unique_hash =
+      if algo = opts[:hash] do
+        :crypto.hash(algo, normalised_url)
+      else
+        normalised_url
+      end
+
+    case Map.get(unique_request_seen_requests, unique_hash) do
       nil ->
         unique_request_seen_requests =
-          Map.put(unique_request_seen_requests, request.url, true)
+          Map.put(unique_request_seen_requests, unique_hash, true)
 
         new_state =
           Map.put(

--- a/test/middlewares/unique_request_test.exs
+++ b/test/middlewares/unique_request_test.exs
@@ -2,6 +2,7 @@ defmodule Middlewares.UniqueRequestTest do
   use ExUnit.Case, async: false
 
   @valid %Crawly.Request{url: "https://www.some_url.com"}
+  @valid_slash %Crawly.Request{url: "https://www.some_url.com/"}
 
   test "Filters out requests non-unique urls" do
     middlewares = [Crawly.Middlewares.UniqueRequest]
@@ -11,5 +12,24 @@ defmodule Middlewares.UniqueRequestTest do
     assert {_req, state} = Crawly.Utils.pipe(middlewares, req, state)
     # run again, should drop the request
     assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+
+  test "Filters out requests non-unique urls using hash" do
+    middlewares = [{Crawly.Middlewares.UniqueRequest, hash: :sha256}]
+    req = @valid
+    state = %{spider_name: :test_spider, crawl_id: "123"}
+
+    assert {_req, state} = Crawly.Utils.pipe(middlewares, req, state)
+    # run again, should drop the request
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+
+  test "Ignores trailing slash" do
+    middlewares = [Crawly.Middlewares.UniqueRequest]
+    state = %{spider_name: :test_spider, crawl_id: "123"}
+
+    assert {_req, state} = Crawly.Utils.pipe(middlewares, @valid, state)
+    # run again, should drop the request
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, @valid_slash, state)
   end
 end


### PR DESCRIPTION
* optional hashing (closes elixir-crawly/crawly#143)
* ignore trailing slash, assuming that pathes /a and /a/ yield identical content