### PR TITLE
Increase the error level of some messages

### DIFF
--- a/lib/crawly.ex
+++ b/lib/crawly.ex
@@ -141,7 +141,7 @@ defmodule Crawly do
       Crawly.Models.YMLSpider.load()
     rescue
       error ->
-        Logger.debug("Could not load spiders: #{inspect(error)}")
+        Logger.error("Could not load spiders: #{inspect(error)}")
     end
   end
 end

--- a/lib/crawly.ex
+++ b/lib/crawly.ex
@@ -141,7 +141,7 @@ defmodule Crawly do
       Crawly.Models.YMLSpider.load()
     rescue
       error ->
-        Logger.error("Could not load spiders: #{inspect(error)}")
+        Logger.info("No spiders found to auto-load: #{inspect(error)}")
     end
   end
 end

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -48,7 +48,7 @@ defmodule Crawly.Engine do
   def start_spider(spider_name, opts \\ [])
 
   def start_spider(spider_name, crawl_id) when is_binary(crawl_id) do
-    Logger.warn(
+    Logger.warning(
       "Deprecation Warning: Setting the crawl_id as second positional argument is deprecated. Please use the :crawl_id option instead. Refer to docs for more info (https://hexdocs.pm/crawly/Crawly.Engine.html#start_spider/2) "
     )
 
@@ -67,7 +67,7 @@ defmodule Crawly.Engine do
         configure_spider_logs(spider_name, opts[:crawl_id])
 
       {true, false} ->
-        Logger.warn(
+        Logger.error(
           ":logger_file_backend https://github.com/onkel-dirtus/logger_file_backend#loggerfilebackend must be installed as a peer dependency if log_to_file config is set to true"
         )
 

--- a/lib/crawly/pipelines/duplicates_filter.ex
+++ b/lib/crawly/pipelines/duplicates_filter.ex
@@ -38,7 +38,7 @@ defmodule Crawly.Pipelines.DuplicatesFilter do
 
     case item_id do
       nil ->
-        Logger.info(
+        Logger.error(
           "Duplicates filter pipeline is inactive, item_id option is required
           to make it operational."
         )

--- a/lib/crawly/pipelines/validate.ex
+++ b/lib/crawly/pipelines/validate.ex
@@ -47,7 +47,7 @@ defmodule Crawly.Pipelines.Validate do
         {item, state}
 
       _ ->
-        Logger.info(
+        Logger.warning(
           "Dropping item: #{inspect(item)}. Reason: missing required fields"
         )
 

--- a/lib/crawly/requests_storage/requests_storage_worker.ex
+++ b/lib/crawly/requests_storage/requests_storage_worker.ex
@@ -95,7 +95,7 @@ defmodule Crawly.RequestsStorage.Worker do
     GenServer.call(pid, command)
   catch
     error, reason ->
-      Logger.debug(Exception.format(error, reason, __STACKTRACE__))
+      Logger.error(Exception.format(error, reason, __STACKTRACE__))
   end
 
   defp pipe_request(request, state) do

--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -51,7 +51,7 @@ defmodule Crawly.Worker do
             :ok
           else
             {:error, reason} ->
-              Logger.debug(
+              Logger.warning(
                 "Crawly worker could not process the request to #{inspect(request.url)} reason: #{inspect(reason)}"
               )
           end
@@ -122,11 +122,11 @@ defmodule Crawly.Worker do
       {:ok, {parsed_item, response, spider_name}}
     catch
       error, reason ->
-        Logger.debug(
+        Logger.warning(
           "Could not parse item, error: #{inspect(error)}, reason: #{inspect(reason)}"
         )
 
-        Logger.debug(Exception.format(:error, error, __STACKTRACE__))
+        Logger.warning(Exception.format(:error, error, __STACKTRACE__))
 
         {:error, reason}
     end


### PR DESCRIPTION
See https://github.com/elixir-crawly/crawly/discussions/270. In a nutshell, some errors are being logged as `debug`. This causes them to be hidden if the user is running Crawly as a normal user, at e.g. `info` or `warn` level.

* This PR increases the log level of these. 
* A few other logging statements are changed to hopefully better match the severity.
* E.g., some notifications were raised to `error` because they indicate a configuration error, and the app won't function as expected.