### PR TITLE
Update returned value to avoid VSCode ElixirLS warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ historical archival.
             |> Crawly.Utils.request_from_url()
           end)
 
-        %{items: items, requests: next_requests}
+        %Crawly.ParsedItem{items: items, requests: next_requests}
       end
     end
    ```


### PR DESCRIPTION
New to Elixir and decided to try using Crawly as a first app. I was getting a warning saying that I was returning the wrong type when copying the sample crawler in the README. Finally figured out it was because I was just returning `%{}` instead of `%Crawly.ParsedItem{}` since the former was what was the README shows. This is really minor as it didn't affect the correctness of the program, but I figured it might be helpful to have the README so that it didn't trigger this warning.

For reference, here's the error text:
```
Type mismatch for @callback parse_item/1 in Crawly.Spider behaviour.

Expected type:
%Crawly.ParsedItem{
  :items => [map()],
  :requests => [
    %Crawly.Request{
      :headers => [{binary(), binary()}],
      :middlewares => [atom()],
      :options => Keyword.t(binary()),
      :prev_response => %{},
      :retries => non_neg_integer(),
      :url => binary()
    }
  ]
}

Actual type:
%{:items => [%{:title => binary()}, ...], :requests => []}
ElixirLS Dialyzer
```