### PR TITLE
Fix Crawly interactive shell start for Elixir 1.17

### DIFF
--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -139,9 +139,13 @@ defmodule Crawly.Engine do
 
   @spec init(any) :: {:ok, t()}
   def init(_args) do
+    {:ok, %Crawly.Engine{}, {:continue, :get_known_spiders}}
+  end
+
+  def handle_continue(:get_known_spiders, state) do
     spiders = get_updated_known_spider_list()
 
-    {:ok, %Crawly.Engine{known_spiders: spiders}}
+    {:noreply, %{state | known_spiders: spiders}}
   end
 
   def handle_call({:get_manager, spider_name}, _, state) do


### PR DESCRIPTION
Crawly's Engine could not start with a new version of Elixir, due to the fact that `Crawly.Utils.list_spiders()` was taking too long (and probably could not be loaded) I have moved this operation to a handle_continue, so the App starts normally