### PR TITLE
Fix Crawly.Utils.list_spiders/0

### DIFF
--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -162,7 +162,7 @@ defmodule Crawly.Utils do
       fn mod, acc ->
         try do
           behaviors =
-            Keyword.take(mod.__info__(:attributes), [:behaviour])
+            Keyword.take(mod.module_info(:attributes), [:behaviour])
             |> Keyword.values()
             |> List.flatten()
 
@@ -177,8 +177,11 @@ defmodule Crawly.Utils do
               acc
           end
         rescue
-          _error ->
-            # Just ignore the case, as probably the given module is not a Spider
+          error ->
+            Logger.debug(
+              "Could not classify module #{mod} as spider: #{inspect(error)}"
+            )
+
             acc
         end
       end


### PR DESCRIPTION
The list_spiders function is a bit tricky, it was using __info__ method, that as I see does not work in quite a few cases. Even worse it was just hanging when :shell_defaults.__info__ was called.

I decided to change the function to use .module_info instead, and added some debug loggings