### PR TITLE
remove circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Crawly
 
-[![Crawly](https://circleci.com/gh/elixir-crawly/crawly.svg?style=svg)](https://app.circleci.com/pipelines/github/elixir-crawly)
 [![Module Version](https://img.shields.io/hexpm/v/crawly.svg)](https://hex.pm/packages/crawly)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/crawly/)
 [![Total Download](https://img.shields.io/hexpm/dt/crawly.svg)](https://hex.pm/packages/crawly)


### PR DESCRIPTION
I think that in this [PR](https://github.com/elixir-crawly/crawly/pull/289), which migrates from circleci to gh-actions, the circleci badge in the readme was not deleted.